### PR TITLE
Fix Typescript Error: Update Case of Import File

### DIFF
--- a/projects/ng2-image-compress/src/lib/ng2-image-compress.module.ts
+++ b/projects/ng2-image-compress/src/lib/ng2-image-compress.module.ts
@@ -1,5 +1,5 @@
 import { NgModule,ModuleWithProviders  } from '@angular/core';
-import { ImageUtilityService } from "./imageutilityservice"
+import { ImageUtilityService } from "./ImageUtilityService"
 import { ImageCompressService } from "./ng2-image-compress.service"
 
 @NgModule({


### PR DESCRIPTION
Importing ImageUtilityService.d.ts in all lowercase is causing a typescript compilation error in the latest version. Matching cases resolve the issue.